### PR TITLE
feat: Use Sh instead of Bash for remote:shell target

### DIFF
--- a/resources/dc/build.xml
+++ b/resources/dc/build.xml
@@ -52,7 +52,7 @@
       <arg value="exec"/>
       <arg value="-it"/>
       <arg value="${dc.project-name}-fpm-1"/>
-      <arg value="/bin/bash"/>
+      <arg value="/bin/sh"/>
     </exec>
   </target>
 


### PR DESCRIPTION
Changing from bash to sh fixes missing new lines when typing commands in terminal.
It seems bash doesn't read terminal columns and rows.